### PR TITLE
thoughts on a Qubes-projects folder

### DIFF
--- a/docs/qubes-doc-folders.txt
+++ b/docs/qubes-doc-folders.txt
@@ -13,6 +13,7 @@ hardware
 installing
 managing-os
 privacy
+qubes-daily-apps
 qubes-projects
 reference
 releases

--- a/docs/qubes-doc-folders.txt
+++ b/docs/qubes-doc-folders.txt
@@ -13,6 +13,7 @@ hardware
 installing
 managing-os
 privacy
+qubes-projects
 reference
 releases
 security


### PR DESCRIPTION
Suggestion for a folder, qubes-projects, which allows sub-folders with more individual freedom on content-structure, for as long it is kept inside this single sub-folder for every project. It also makes it easier to find all Qubes projects in a single location, whether briefly documented, or extensively documented, keeping them all together makes it easier to navigate. For example Qubes-TV may have a couple of different documents here, or Qubes-Binary-Router documentations. Projects like these and other projects that people may put up, or found elsewhere on the internet, could fit neatly in such a specialized folder. Thoughts on this? 

Examples
- /contents/docs/qubes-projects/qubes-tv/broader-content-structure-freedom.
- /contents/docs/qubes-projects/qubes-binary-router/broader-content-structure-freedom.
- etc.

Edit: A second folder suggestion for minor projects, which is more focused on specific Apps/VM's. Similar in nature to qubes-projects, but not quite as complex to be classified as a project, and also unlike projects it moves away from the nature of being a "product" and is instead more focused on user experience on Qubes in regards to 3rd party solutions. For example various uses with Qubes, like good notebook/password/bookmark managers, open source chat systems, other recommended open source apps to use with qubes, how to get these to work on Qubes, things like that. It could be called something along the lines of qubes-daily-apps 

Example 
- /contents/docs/qubes-daily-apps/turtl-notebook-manager.md
- /contents/docs/qubes-daily-apps/wire-chat/contents
- /contents/docs/qubes-daily-apps/voice-control-apps/contents
- /contents/docs/qubes-daily-apps/optimizing-keypass-usage.md
- etc. 