### PR TITLE
Update R4-universal-update-script.sh

### DIFF
--- a/code/OS-administration/R4-universal-update-script.sh
+++ b/code/OS-administration/R4-universal-update-script.sh
@@ -40,6 +40,8 @@
 ##    - If succesful, it removes one of the two major concerns of including the -y attribute, making it easier to use.
 ##4) Investigate whether --clean can be removed or changed from the dom0 update command.
 ##5) Investigate the feasibility of a simple GUI interface to select or de-select script script-options (possibly long-term).
+##6) Fixing the progress bar, and picking the best approach to inform the user.
+##7) A better means to stop the script pre-maturely but safely, because it is a long chain of events to update all VM's.
 
 
 
@@ -47,7 +49,7 @@
 ## This warning meesage can be disabled with a #. It includes essential warning for new users
 ## not aware of the pitfalls of scripts. Its highly recommended that new users study how the
 ## script works, it's not very complicated, but also not straight simple either.
-zenity --width="420" --height="200" --title="Welcome to uQUS!" --info --text='This script allows you to easily keep Qubes 4 in a good state with proper update maintenance.\n\n\- Warning! Please read the comments inside the script carefully before running this script.\n' 2> /dev/null
+zenity --width="420" --height="200" --title="Welcome to UQUS!" --info --text='This script allows you to easily keep Qubes 4 in a good state with proper update maintenance.\n\n\- Warning! Please read the comments inside the script carefully before running this script, and remember to do your routine backups.\n' 2> /dev/null
 
 
 #xterm -e 'sudo qubes-dom0-update --clean'

--- a/code/OS-administration/R4-universal-update-script.sh
+++ b/code/OS-administration/R4-universal-update-script.sh
@@ -1,124 +1,102 @@
 #!/bin/sh
 
-#Title description
-##Unofficial, Qubes Universal Update Script (uQUS).
+# Title description:
+## Universal Qubes Update Script (UQUS).
 
-#>>>>WARNING!<<<<
-##Please read the script carefully, do not run if you do not know what it does.
-##Be sure you edit it correctly to your own needs.
+# Quick purpose overview:
+## This script performs auto-updates of dom0 and every default template, as well as any templates
+## you may wish to add. The script is straight forward and highly customizeable. 
 
-#Disclaimer:
-## - At this point in time, this script has not been quality reviewed.
-## - Feel free to critesize by suggesting constructive improvements, or by commit to
-##   the script on github.
-## - We, or I, take no responsibility for use of this script, please study it before
-##   you use this unfinished script at your own risk.
+# >>>>WARNING!<<<<
+## Please read the script carefully, do not run if you do not know what it does.
+## Be sure you edit it correctly to your own needs.
 
-#Authors:
-##Aekez @ https://github.com/Qubes-Community
+# >>>Disclaimer!<<<
+## I take no responsibility for use of this script, please study it before you use this script at your own risk. 
+## However I gureantee and stand by the ideal and belief to improve the quality and reliability as far as possible
+## within my capability and reach, and reasonable circumstances, such as being aware, and having the time to fix it.
 
-#Quick purpose overview:
-## This script performs auto-updates of dom0 and every default template. The script is
-## highly customizeable, warning message/Quick-Backup/repositories, can be adjusted or
-## disabled. It also includes a quick optional qvm-backup reminder/starter. If you use
-## backup profiles instead of manually configuring which VMs to include or exclude in
-## the qvm-backup, then all you need to do is to adjust the qvm-backup command below,
-## similar to how you normally would execute the command in dom0 terminal.
+# Authors:
+## Aekez @ https://github.com/Qubes-Community
 
-#Important notes
-##1) Be sure you have enough free RAM to run the largest RAM intensive template, one at a time.
-##2) The script will halt if it is interupted, such as not enoguh RAM.
-##3) VMs will shutdown automatically if no updates, or after succesfull update install.
+# Feedback & Contributions:
+## Feedback and/or new contributoers are welcome, please use QCC Pull Request, or feel free to contact me.
+
+# Important usage notes:
+##1) Be sure you have enough free RAM to run every updated template, all are run one at a time.
+##2) The script will halt if it is interupted, such as not enoguh RAM, errors/logs are currently not reported.
+##3) VMs will proceed and shutdown automatically if no updates, or after succesfull update install.
 ##4) You may include the -y option to auto-accept updates in some VMs, be careful though.
-##5) You can disable the Quick Backup, however if you use it then remember to configure it.
-##6) Add or remove # in front of the command instructions to disable/enable commands.
-##7) Its essential to keep dom0/templates in sync between repositories.
-##8) Repositories must be in sync, such as between stable & current-testing for dom0/tempaltes.
-##9) Only use current-testing if you know what you are getting yourself into (untested updates).
-#10) This script release version is only tested on Qubes 4.0.
+##5) Add or remove # in front of the command instructions to disable/enable commands.
+##6) Its essential to keep dom0/templates in sync between repositories, don't mix current and current-testing.
+##7) Only use current-testing if you know what you are getting yourself into (untested updates).
+##8) This script release version is only tested on Qubes 4.0, but presumably may work on Qubes 3.2.
 
-#Warning message
-##This warning meesage can be disabled with a #. It includes essential warning for new users
-##not aware of the pitfalls of scripts. Its highly recommended that new users study how the
-##script works, it's not very complicated, but also not straight simple either.
-zenity --width="420" --height="200" --title="Welcome to uQUS!" --info --text='This script allows you to easily keep Qubes 4 in a good state with proper update maintenance.\n\n\- Warning! Please read the comments inside the script carefully before running this script.\n\n- The script is out-of-the-box safety locked, you need to edit the "#" to enable features. Quick Backup and Reboot prompt are by default enabled, as you will notice when you click "ok" below, however requires an address path and target BackupVM. Please decline the next two prompts, and then edit the script for your needs.\n\n Please do not use Quick Backup before you manually adjusted it to your needs inside the script.' 2> /dev/null
-
-
-#Quick Backup Redundancy
-##The purpose here is to serve as a reminder to backup before performing updates. Updates always
-##carry a risk of making the system unbootable. This serves as a popup message, which you
-##can decline to continue without starting qvm-backup, or click yes to perform your qvm-backup.
-##Keep in mind you need to adjust it below to your own customized qvm-backup. The default will
-##only exclude system dom0 & default templates. However a proper path/src-VM is still required.
-##Remember to put the backup externally, so that you can access it if the system does not boot.
-##Partial credit for this section rhss6-2011 @ https://ubuntuforums.org/showthread.php?t=2239195
-qubes-backup='sudo qvm-backup -d add-VM-name-here "/home/user/" -x fedora-26 -x debian-9 -x whonix-ws -x whonix-gw -x sys-net -x sys-firewall -x sys-usb -x sys-whonix -x fedora-26-dvm -x whonix-ws-dvm -x anon-whonix'
-ans=$(zenity --width="420" --height="200" --title="Welcome to uQUS!" --question --text='Must have sufficient free RAM to run the uQUS.\n\nPllease select if you want to perform a pre-selected AppVM backup. To execute a backup profile, or specific inclusion/exclusion of VMs, can be modified and standardized within the script.' --ok-label="Yes" --cancel-label="No" 2> /dev/null
-if [ $? = 0 ] ; then
-command=$(xterm -e $qubes-backup)
-else
-command=$()
-fi
-)
+# To-do notes:
+##1) Further streamline script, making it easier to customize with symbolic links.
+##2) Reducing the risk that users mistakenly run testing, or out-of-sync dom0/template updates.
+##3) If feasible, presenting the logs for each update, saved in a dated folder for every time script is run.
+##    - If feasible, reporting errors and logs to the user during or after the update has finished.
+##    - If succesful, it removes one of the two major concerns of including the -y attribute, making it easier to use.
+##4) Investigate whether --clean can be removed or changed from the dom0 update command.
+##5) Investigate the feasibility of a simple GUI interface to select or de-select script script-options (possibly long-term).
 
 
-##Qubes dom0 updates
+
+# Warning message:
+## This warning meesage can be disabled with a #. It includes essential warning for new users
+## not aware of the pitfalls of scripts. Its highly recommended that new users study how the
+## script works, it's not very complicated, but also not straight simple either.
+zenity --width="420" --height="200" --title="Welcome to uQUS!" --info --text='This script allows you to easily keep Qubes 4 in a good state with proper update maintenance.\n\n\- Warning! Please read the comments inside the script carefully before running this script.\n' 2> /dev/null
+
+
 #xterm -e 'sudo qubes-dom0-update --clean'
 #xterm -e 'sudo qubes-dom0-update --enablerepo=qubes-dom0-current-testing --clean'
 wait
 echo -ne "$(tput setaf 4)($(tput setaf 6)#    $(tput setaf 4)) $(tput setaf 6)Dom0 update has finished.$(tput setaf 9)\n"
 
 
-##Default Qubes fedora template - Only enable one repository, and keep the same type across all templates/dom0.
-#qvm-start fedora-26 #Needed to avoid premature qvm-run shutdown.
+qvm-start fedora-26 #Needed to avoid premature qvm-run shutdown.
 wait
-#qvm-run fedora-26 'xterm -e sudo dnf update --refresh'
+qvm-run fedora-26 'xterm -e sudo dnf update --refresh'
+wait
 #qvm-run fedora-26 'xterm -e sudo dnf update --enablerepo=qubes-vm-*-current-testing --refresh'
-wait
-#qvm-shutdown fedora-26 #Needed if qvm-start is used.
+#wait
+qvm-shutdown fedora-26 #Needed if qvm-start is used.
 wait
 echo -ne "$(tput setaf 4)(#$(tput setaf 6)#   $(tput setaf 4)) $(tput setaf 6)Fedora-26 update has finished.$(tput setaf 9)\n"
 
 
-##Default Qubes debian template.
-#qvm-start debian-9 #Needed to avoid premature qvm-run shutdown, important here.
+qvm-start debian-9 #Needed to avoid premature qvm-run shutdown, important here.
 wait
-#qvm-run whonix-gw 'xterm -e sudo apt-get check' #Can optionally be enabled to check dependencies and cache-checks.
-wait
-#qvm-run debian-9 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
+qvm-run debian-9 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
 wait
 #qvm-run whonix-gw 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
-wait
-#qvm-shutdown debian-9 #Needed if qvm-start is used.
+#wait
+qvm-shutdown debian-9 #Needed if qvm-start is used.
 wait
 echo -ne "$(tput setaf 4)(##$(tput setaf 6)#  $(tput setaf 4)) $(tput setaf 6)Debian-9 update has finished.$(tput setaf 9)\n"
 
 
 
-##Default Qubes Whonix-WS.
-#qvm-start whonix-ws #Needed to avoid premature qvm-run shutdown, important here.
+qvm-start whonix-ws #Needed to avoid premature qvm-run shutdown, important here.
 wait
-#qvm-run whonix-gw 'xterm -e sudo apt-get check' #Can optionally be enabled to check dependencies and cache-checks.
-wait
-#qvm-run whonix-ws 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
+qvm-run whonix-ws 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
 wait
 #qvm-run whonix-gw 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
-wait
-#qvm-shutdown whonix-ws #Needed if qvm-start is used.
+#wait
+qvm-shutdown whonix-ws #Needed if qvm-start is used.
 wait
 echo -ne "$(tput setaf 4)(###$(tput setaf 6)# $(tput setaf 4)) $(tput setaf 6)Whonix-WS update has finished.$(tput setaf 9)\n"
 
 
-##Default Qubes Whonix-GW. Keep both commands enabled.
-#qvm-start whonix-gw #Needed to avoid premature qvm-run shutdown, important here.
+qvm-start whonix-gw #Needed to avoid premature qvm-run shutdown, important here.
 wait
-#qvm-run whonix-gw 'xterm -e sudo apt-get check' #Can optionally be enabled to check dependencies and cache-checks.
-wait
-#qvm-run whonix-gw 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
+qvm-run whonix-gw 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
 wait
 #qvm-run whonix-gw 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
-wait
-#qvm-shutdown whonix-gw #Needed if qvm-start is used.
+#wait
+qvm-shutdown whonix-gw #Needed if qvm-start is used.
 wait
 echo -ne "$(tput setaf 4)(####$(tput setaf 6)#$(tput setaf 4)) $(tput setaf 6)Whonix-GW update has finished.$(tput setaf 9)\n"
 wait
@@ -129,8 +107,8 @@ echo -ne '\n'$(tput setaf 9)
 #qvm-shutdown sys-whonix #Optional.
 #wait
 
-##Conclusion: Question message, whether to restart or not. Copied logic, credit goes
-##to rhss6-2011 @ https://ubuntuforums.org/showthread.php?t=2239195
+##Conclusion: Question message, whether to restart or not.
+##For this part of the Script logic, credit goes to rhss6-2011 @ https://ubuntuforums.org/showthread.php?t=2239195
 ans=$(zenity --width="420" --height="200" --title="uQUS has reached its conclusion." --question --text='The update-script has successfully reached its conflusion.\n\n- Click "Yes" to perform a full system restart.\n\n- Click "No" if no restart is required or you wish to restart manually later.\n\n- Normal template updates? It is recommended to restart VMs.\n- Qubes OS updates? It is recommended to perofmr a full system re-start.' --ok-label="Yes" --cancel-label="No" 2> /dev/null
 if [ $? = 0 ] ; then
 command=$(xterm -e shutdown -h now) #use 'reboot -h now' instead of shutdown if you want the 'Yes' button to perform a reboot.
@@ -138,6 +116,3 @@ else
 command=$()
 fi
 )
-
-#done
-


### PR DESCRIPTION
- Removing the backup script section from the script and any associated backup commands and warnings. 
  - This is done to streamline the simplicity and purpose of the script. 
  - Reminding users to take backups is outside the scope and purpose, and should be covered in separate scripts/docs. 
  - A backup reminder may be re-introduced if a proper GUI window can be made.
- Removing #-lock on script, so that it can run normal current updates out-of-the-box.
- Improved context and wording, as well as removing lingering redundancy and repeats.
- Overall intention in changes is also to make the script easier to read and getting started.
- Added a To-do table for planned improvements. 
  - Any help to reach these to-do goals sooner, are very welcome, and so are of course also other suggestions, feedback and improvements.