### PR TITLE
Update R4-universal-update-script.sh

### DIFF
--- a/code/OS-administration/R4-universal-update-script.sh
+++ b/code/OS-administration/R4-universal-update-script.sh
@@ -38,7 +38,7 @@
 ##3) If feasible, presenting the logs for each update, saved in a dated folder for every time script is run.
 ##    - If feasible, reporting errors and logs to the user during or after the update has finished.
 ##    - If succesful, it removes one of the two major concerns of including the -y attribute, making it easier to use.
-##4) Investigate whether --clean can be removed or changed from the dom0 update command.
+##4) - (Done) Investigate whether --clean can be removed or changed from the dom0 update command.
 ##5) Investigate the feasibility of a simple GUI interface to select or de-select script script-options (possibly long-term).
 ##6) Fixing the progress bar, and picking the best approach to inform the user.
 ##7) A better means to stop the script pre-maturely but safely, because it is a long chain of events to update all VM's.
@@ -52,45 +52,55 @@
 zenity --width="420" --height="200" --title="Welcome to UQUS!" --info --text='This script allows you to easily keep Qubes 4 in a good state with proper update maintenance.\n\n\- Warning! Please read the comments inside the script carefully before running this script, and remember to do your routine backups.\n' 2> /dev/null
 
 
-#xterm -e 'sudo qubes-dom0-update --clean'
-#xterm -e 'sudo qubes-dom0-update --enablerepo=qubes-dom0-current-testing --clean'
+xterm -e 'sudo qubes-dom0-update --refresh'
+#xterm -e 'sudo qubes-dom0-update --enablerepo=qubes-dom0-current-testing --refresh'
 wait
-echo -ne "$(tput setaf 4)($(tput setaf 6)#    $(tput setaf 4)) $(tput setaf 6)Dom0 update has finished.$(tput setaf 9)\n"
-
-
-qvm-start fedora-26 #Needed to avoid premature qvm-run shutdown.
-wait
-qvm-run fedora-26 'xterm -e sudo dnf update --refresh'
-wait
-#qvm-run fedora-26 'xterm -e sudo dnf update --enablerepo=qubes-vm-*-current-testing --refresh'
+#echo -ne "$(tput setaf 4)($(tput setaf 6)#    $(tput setaf 4)) $(tput setaf 6)Dom0 update has finished.$(tput setaf 9)\n"
 #wait
-qvm-shutdown fedora-26 #Needed if qvm-start is used.
-wait
-echo -ne "$(tput setaf 4)(#$(tput setaf 6)#   $(tput setaf 4)) $(tput setaf 6)Fedora-26 update has finished.$(tput setaf 9)\n"
 
+qvm-start fedora-28 #Needed to avoid premature qvm-run shutdown.
+wait
+qvm-run fedora-28 'xterm -e sudo dnf update --refresh'
+wait
+qvm-run fedora-28 'xterm -e sudo dnf upgrade'
+wait
+#qvm-run fedora-28 'xterm -e sudo dnf update --enablerepo=qubes-vm-*-current-testing --refresh'
+#wait
+#qvm-run fedora-28 'xterm -e sudo dnf upgrade --enablerepo=qubes-vm-*-current-testing'
+#wait
+#qvm-run fedora-28 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+#wait
+qvm-shutdown fedora-28 #Needed if qvm-start is used.
+wait
+#echo -ne "$(tput setaf 4)(#$(tput setaf 6)#   $(tput setaf 4)) $(tput setaf 6)Fedora-28 update has finished.$(tput setaf 9)\n"
+#wait
 
 qvm-start debian-9 #Needed to avoid premature qvm-run shutdown, important here.
 wait
 qvm-run debian-9 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
 wait
-#qvm-run whonix-gw 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
+#qvm-run debian-9 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
 #wait
+#qvm-run debian-9 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+wait
 qvm-shutdown debian-9 #Needed if qvm-start is used.
 wait
-echo -ne "$(tput setaf 4)(##$(tput setaf 6)#  $(tput setaf 4)) $(tput setaf 6)Debian-9 update has finished.$(tput setaf 9)\n"
-
+#echo -ne "$(tput setaf 4)(##$(tput setaf 6)#  $(tput setaf 4)) $(tput setaf 6)Debian-9 update has finished.$(tput setaf 9)\n"
+#wait
 
 
 qvm-start whonix-ws #Needed to avoid premature qvm-run shutdown, important here.
 wait
 qvm-run whonix-ws 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
 wait
-#qvm-run whonix-gw 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
+#qvm-run whonix-ws 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
+#wait
+#qvm-run whonix-ws 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 #wait
 qvm-shutdown whonix-ws #Needed if qvm-start is used.
 wait
-echo -ne "$(tput setaf 4)(###$(tput setaf 6)# $(tput setaf 4)) $(tput setaf 6)Whonix-WS update has finished.$(tput setaf 9)\n"
-
+#echo -ne "$(tput setaf 4)(###$(tput setaf 6)# $(tput setaf 4)) $(tput setaf 6)Whonix-WS update has finished.$(tput setaf 9)\n"
+#wait
 
 qvm-start whonix-gw #Needed to avoid premature qvm-run shutdown, important here.
 wait
@@ -98,13 +108,15 @@ qvm-run whonix-gw 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgr
 wait
 #qvm-run whonix-gw 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
 #wait
+#qvm-run whonix-gw 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+#wait
 qvm-shutdown whonix-gw #Needed if qvm-start is used.
 wait
-echo -ne "$(tput setaf 4)(####$(tput setaf 6)#$(tput setaf 4)) $(tput setaf 6)Whonix-GW update has finished.$(tput setaf 9)\n"
-wait
+#echo -ne "$(tput setaf 4)(####$(tput setaf 6)#$(tput setaf 4)) $(tput setaf 6)Whonix-GW update has finished.$(tput setaf 9)\n"
+#wait
 
-echo -ne "$(tput setaf 4)(#####) $(tput setaf 6)The uQUS script has finished.\n"
-echo -ne '\n'$(tput setaf 9)
+#echo -ne "$(tput setaf 4)(#####) $(tput setaf 6)The uQUS script has finished.\n"
+#echo -ne '\n'$(tput setaf 9)
 
 #qvm-shutdown sys-whonix #Optional.
 #wait

--- a/code/OS-administration/R4-universal-update-script.sh
+++ b/code/OS-administration/R4-universal-update-script.sh
@@ -21,6 +21,7 @@
 # /// Special settings \\\
 #toggle-shutdown-sys-whonix='qvm-shutdown sys-whonix --wait' # Enable/Disable this second-last command at bottom of script.
 
+
 # /// Testing Updates \\\
 ## Removing or inserting the hash-# sign on below lines will disable/enable Qubes testing updates.
 ## If using testing repositories, make sure you keep all domains (Dom0 and DomUs') in sync.
@@ -68,149 +69,187 @@ debian_based_template_3='whonix-gw'
 # It is therefore very easy to copy/paste to create more slots, and modify extra numbers.
 
 # Fedora/Fedora-minimal/CentOS-based update slot #1
+if [ "$fedora_based_template_1" ]; then
 qvm-start "$fedora_based_template_1" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_1" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #2
+if [ "$fedora_based_template_2" ]; then
 qvm-start "$fedora_based_template_2" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_2" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #3
+if [ "$fedora_based_template_3" ]; then
 qvm-start "$fedora_based_template_3" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_3" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #4
+if [ "$fedora_based_template_4" ]; then
 qvm-start "$fedora_based_template_4" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_4" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #5
+if [ "$fedora_based_template_5" ]; then
 qvm-start "$fedora_based_template_5" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_5" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #6
+if [ "$fedora_based_template_6" ]; then
 qvm-start "$fedora_based_template_6" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_6" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_6" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_6" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_6" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #7
+if [ "$fedora_based_template_7" ]; then
 qvm-start "$fedora_based_template_7" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_7" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_7" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_7" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_7" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #8
+if [ "$fedora_based_template_8" ]; then
 qvm-start "$fedora_based_template_8" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_8" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_8" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_8" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_8" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #9
+if [ "$fedora_based_template_9" ]; then
 qvm-start "$fedora_based_template_9" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_9" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_9" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_9" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_9" --wait #Needed if qvm-start is used.
+fi
 
 # Fedora/Fedora-minimal/CentOS-based update slot #10
+if [ "$fedora_based_template_10" ]; then
 qvm-start "$fedora_based_template_10" #Needed to avoid premature qvm-run shutdown.
 qvm-run "$fedora_based_template_10" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 qvm-run "$fedora_based_template_10" 'xterm -e sudo dnf upgrade '$fedora_testing''
 #qvm-run "$fedora_based_template_10" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$fedora_based_template_10" --wait #Needed if qvm-start is used.
-
+fi
 
 # <<< !!! Switching from Fedora-based to Debian-based updates !!! >>> 
 
 
 # Debian/Whonix-based update slot #1
+if [ "$debian_based_template_1" ]; then
 qvm-start "$debian_based_template_1" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_1" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_1" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_1" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_1" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #2
+if [ "$debian_based_template_2" ]; then
 qvm-start "$debian_based_template_2" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_2" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_2" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_2" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_2" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #3
+if [ "$debian_based_template_3" ]; then
 qvm-start "$debian_based_template_3" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_3" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_3" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_3" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_3" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #4
+if [ "$debian_based_template_4" ]; then
 qvm-start "$debian_based_template_4" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_4" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_4" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_4" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_4" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #5
+if [ "$debian_based_template_5" ]; then
 qvm-start "$debian_based_template_5" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_5" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_5" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_5" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_5" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #6
+if [ "$debian_based_template_6" ]; then
 qvm-start "$debian_based_template_6" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_6" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_6" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_6" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_6" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #7
+if [ "$debian_based_template_7" ]; then
 qvm-start "$debian_based_template_7" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_7" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_7" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_7" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_7" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #8
+if [ "$debian_based_template_8" ]; then
 qvm-start "$debian_based_template_8" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_8" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_8" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_8" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_8" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #9
+if [ "$debian_based_template_9" ]; then
 qvm-start "$debian_based_template_9" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_9" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_9" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_9" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_9" --wait #Needed if qvm-start is used.
+fi
 
 # Debian/Whonix-based update slot #10
+if [ "$debian_based_template_10" ]; then
 qvm-start "$debian_based_template_10" #Needed to avoid premature qvm-run shutdown, important here.
 qvm-run "$debian_based_template_10" "xterm -e sudo apt-get update '$debian_testing'"
 qvm-run "$debian_based_template_10" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_10" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 qvm-shutdown "$debian_based_template_10" --wait #Needed if qvm-start is used.
-
+fi
 
 $(toggle-shutdown-sys-whonix)
 

--- a/code/OS-administration/R4-universal-update-script.sh
+++ b/code/OS-administration/R4-universal-update-script.sh
@@ -1,122 +1,181 @@
 #!/bin/sh
 
-# Title description:
+# >>>>Title<<<<
 ## Universal Qubes Update Script (UQUS).
 
-# Quick purpose overview:
+# >>>>Purpose<<<<
 ## This script performs auto-updates of dom0 and every default template, as well as any templates
 ## you may wish to add. The script is straight forward and highly customizeable. 
 
 # >>>>WARNING!<<<<
 ## Please read the script carefully, do not run if you do not know what it does.
 ## Be sure you edit it correctly to your own needs.
+## Useage notes and to-do-notes can be found at the bottom of the script.
 
 # >>>Disclaimer!<<<
 ## I take no responsibility for use of this script, please study it before you use this script at your own risk. 
 ## However I gureantee and stand by the ideal and belief to improve the quality and reliability as far as possible
 ## within my capability and reach, and reasonable circumstances, such as being aware, and having the time to fix it.
 
-# Authors:
-## Aekez @ https://github.com/Qubes-Community
-
-# Feedback & Contributions:
-## Feedback and/or new contributoers are welcome, please use QCC Pull Request, or feel free to contact me.
-
-# Important usage notes:
-##1) Be sure you have enough free RAM to run every updated template, all are run one at a time.
-##2) The script will halt if it is interupted, such as not enoguh RAM, errors/logs are currently not reported.
-##3) VMs will proceed and shutdown automatically if no updates, or after succesfull update install.
-##4) You may include the -y option to auto-accept updates in some VMs, be careful though.
-##5) Add or remove # in front of the command instructions to disable/enable commands.
-##6) Its essential to keep dom0/templates in sync between repositories, don't mix current and current-testing.
-##7) Only use current-testing if you know what you are getting yourself into (untested updates).
-##8) This script release version is only tested on Qubes 4.0, but presumably may work on Qubes 3.2.
-
-# To-do notes:
-##1) Further streamline script, making it easier to customize with symbolic links.
-##2) Reducing the risk that users mistakenly run testing, or out-of-sync dom0/template updates.
-##3) If feasible, presenting the logs for each update, saved in a dated folder for every time script is run.
-##    - If feasible, reporting errors and logs to the user during or after the update has finished.
-##    - If succesful, it removes one of the two major concerns of including the -y attribute, making it easier to use.
-##4) - (Done) Investigate whether --clean can be removed or changed from the dom0 update command.
-##5) Investigate the feasibility of a simple GUI interface to select or de-select script script-options (possibly long-term).
-##6) Fixing the progress bar, and picking the best approach to inform the user.
-##7) A better means to stop the script pre-maturely but safely, because it is a long chain of events to update all VM's.
 
 
 
-# Warning message:
-## This warning meesage can be disabled with a #. It includes essential warning for new users
-## not aware of the pitfalls of scripts. Its highly recommended that new users study how the
-## script works, it's not very complicated, but also not straight simple either.
-zenity --width="420" --height="200" --title="Welcome to UQUS!" --info --text='This script allows you to easily keep Qubes 4 in a good state with proper update maintenance.\n\n\- Warning! Please read the comments inside the script carefully before running this script, and remember to do your routine backups.\n' 2> /dev/null
+# /// Testing Updates \\\
+## Removing or inserting the hash-# sign on below lines will disable/enable Qubes testing updates.
+## If using testing repositories, make sure you keep all domains (Dom0 and DomUs') in sync.
+#dom0_testing='--enablerepo=qubes-dom0-current-testing'
+#fedora_testing='--enablerepo=qubes-vm-*-current-testing' # Includes all CentOS and Fedora-Minimal templates.
+#debian_testing='-t *-testing' # Includes all Whonix templates.
 
-
-xterm -e 'sudo qubes-dom0-update --refresh'
-#xterm -e 'sudo qubes-dom0-update --enablerepo=qubes-dom0-current-testing --refresh'
+# /// Dom0 updates \\\
+xterm -e 'sudo qubes-dom0-update '$dom0_testing' --refresh'
 wait
-#echo -ne "$(tput setaf 4)($(tput setaf 6)#    $(tput setaf 4)) $(tput setaf 6)Dom0 update has finished.$(tput setaf 9)\n"
+
+# /// Template Script slots \\\
+## You can insert values in the slots below, and/or add more slots in the script.
+## Be sure you match the slots with the commands and values further down the script.
+## Disabling a slot with hash-#, will disable updates for specified VM.
+
+# Fedora_based script slots include all Fedora, Fedora-minimal and CentOS templates.
+fedora_based_template_1='fedora-28'
+#fedora_based_template_2=''
+#fedora_based_template_3=''
+#fedora_based_template_4=''
+#fedora_based_template_5=''
+
+# Debian_based script slots include all Debian / Whonix templates. 
+debian_based_template_1='debian-9'
+#debian_based_template_2=''
+#debian_based_template_3=''
+debian_based_template_4='whonix-ws'
+debian_based_template_5='whonix-gw'
+
+
+
+
+# /// Inner Script mechanics below \\\
+# You only need to modify the below if you plan to go beyond the normal scope 
+# of the scripts purpose, and/or if you want to expand the number of included slots.
+# All fedora-based, and all debian-based slots are identical, except for slot numbers.
+# It is therefore very easy to copy/paste to create more slots, and modify extra numbers.
+
+# Fedora/Fedora-minimal/CentOS-based update slot #1
+qvm-start "$fedora_based_template_1" #Needed to avoid premature qvm-run shutdown.
+wait
+qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+wait
+qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf upgrade '$fedora_testing''
+wait
+#qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 #wait
+qvm-shutdown "$fedora_based_template_1" #Needed if qvm-start is used.
+wait
 
-qvm-start fedora-28 #Needed to avoid premature qvm-run shutdown.
+# Fedora/Fedora-minimal/CentOS-based update slot #2
+qvm-start "$fedora_based_template_2" #Needed to avoid premature qvm-run shutdown.
 wait
-qvm-run fedora-28 'xterm -e sudo dnf update --refresh'
+qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 wait
-qvm-run fedora-28 'xterm -e sudo dnf upgrade'
+qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf upgrade '$fedora_testing''
 wait
-#qvm-run fedora-28 'xterm -e sudo dnf update --enablerepo=qubes-vm-*-current-testing --refresh'
+#qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 #wait
-#qvm-run fedora-28 'xterm -e sudo dnf upgrade --enablerepo=qubes-vm-*-current-testing'
-#wait
-#qvm-run fedora-28 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown fedora-28 #Needed if qvm-start is used.
+qvm-shutdown "$fedora_based_template_2" #Needed if qvm-start is used.
 wait
-#echo -ne "$(tput setaf 4)(#$(tput setaf 6)#   $(tput setaf 4)) $(tput setaf 6)Fedora-28 update has finished.$(tput setaf 9)\n"
-#wait
 
-qvm-start debian-9 #Needed to avoid premature qvm-run shutdown, important here.
+# Fedora/Fedora-minimal/CentOS-based update slot #3
+qvm-start "$fedora_based_template_3" #Needed to avoid premature qvm-run shutdown.
 wait
-qvm-run debian-9 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
+qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
 wait
-#qvm-run debian-9 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
+qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf upgrade '$fedora_testing''
+wait
+#qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 #wait
-#qvm-run debian-9 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$fedora_based_template_3" #Needed if qvm-start is used.
 wait
-qvm-shutdown debian-9 #Needed if qvm-start is used.
+
+# Fedora/Fedora-minimal/CentOS-based update slot #4
+qvm-start "$fedora_based_template_4" #Needed to avoid premature qvm-run shutdown.
 wait
-#echo -ne "$(tput setaf 4)(##$(tput setaf 6)#  $(tput setaf 4)) $(tput setaf 6)Debian-9 update has finished.$(tput setaf 9)\n"
+qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+wait
+qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf upgrade '$fedora_testing''
+wait
+#qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
 #wait
+qvm-shutdown "$fedora_based_template_4" #Needed if qvm-start is used.
+wait
+
+# Fedora/Fedora-minimal/CentOS-based update slot #5
+qvm-start "$fedora_based_template_5" #Needed to avoid premature qvm-run shutdown.
+wait
+qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+wait
+qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf upgrade '$fedora_testing''
+wait
+#qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+#wait
+qvm-shutdown "$fedora_based_template_5" #Needed if qvm-start is used.
+wait
 
 
-qvm-start whonix-ws #Needed to avoid premature qvm-run shutdown, important here.
-wait
-qvm-run whonix-ws 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
-wait
-#qvm-run whonix-ws 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
-#wait
-#qvm-run whonix-ws 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown whonix-ws #Needed if qvm-start is used.
-wait
-#echo -ne "$(tput setaf 4)(###$(tput setaf 6)# $(tput setaf 4)) $(tput setaf 6)Whonix-WS update has finished.$(tput setaf 9)\n"
-#wait
 
-qvm-start whonix-gw #Needed to avoid premature qvm-run shutdown, important here.
-wait
-qvm-run whonix-gw 'xterm -e sudo apt-get update; xterm -e sudo apt-get dist-upgrade'
-wait
-#qvm-run whonix-gw 'xterm -e sudo apt-get update -t *-testing; xterm -e sudo apt-get dist-upgrade -t *-testing'
-#wait
-#qvm-run whonix-gw 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown whonix-gw #Needed if qvm-start is used.
-wait
-#echo -ne "$(tput setaf 4)(####$(tput setaf 6)#$(tput setaf 4)) $(tput setaf 6)Whonix-GW update has finished.$(tput setaf 9)\n"
-#wait
 
-#echo -ne "$(tput setaf 4)(#####) $(tput setaf 6)The uQUS script has finished.\n"
-#echo -ne '\n'$(tput setaf 9)
+
+# Debian/Whonix-based update slot #1
+qvm-start "$debian_based_template_1" #Needed to avoid premature qvm-run shutdown, important here.
+wait
+qvm-run "$debian_based_template_1" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
+wait
+#qvm-run "$debian_based_template_1" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+wait
+qvm-shutdown "$debian_based_template_1" #Needed if qvm-start is used.
+wait
+
+# Debian/Whonix-based update slot #2
+qvm-start "$debian_based_template_2" #Needed to avoid premature qvm-run shutdown, important here.
+wait
+qvm-run "$debian_based_template_2" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
+wait
+#qvm-run "$debian_based_template_2" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+wait
+qvm-shutdown "$debian_based_template_2" #Needed if qvm-start is used.
+wait
+
+# Debian/Whonix-based update slot #3
+qvm-start "$debian_based_template_3" #Needed to avoid premature qvm-run shutdown, important here.
+wait
+qvm-run "$debian_based_template_3" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
+wait
+#qvm-run "$debian_based_template_3" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+wait
+qvm-shutdown "$debian_based_template_3" #Needed if qvm-start is used.
+wait
+
+# Debian/Whonix-based update slot #4
+qvm-start "$debian_based_template_4" #Needed to avoid premature qvm-run shutdown, important here.
+wait
+qvm-run "$debian_based_template_4" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
+wait
+#qvm-run "$debian_based_template_4" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+wait
+qvm-shutdown "$debian_based_template_4" #Needed if qvm-start is used.
+wait
+
+# Debian/Whonix-based update slot #5
+qvm-start "$debian_based_template_5" #Needed to avoid premature qvm-run shutdown, important here.
+wait
+qvm-run "$debian_based_template_5" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
+wait
+#qvm-run "$debian_based_template_5" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+wait
+qvm-shutdown "$debian_based_template_5" #Needed if qvm-start is used.
+wait
+
+
+
+
 
 #qvm-shutdown sys-whonix #Optional.
 #wait
@@ -130,3 +189,31 @@ else
 command=$()
 fi
 )
+
+
+# >>>>usage-notes!<<<<
+##1) Be sure you have enough free RAM to run every updated template, all are run one at a time.
+##2) The script will halt if it is interupted, such as not enoguh RAM, errors/logs are currently not reported.
+##3) VMs will proceed and shutdown automatically if no updates, or after succesfull update install.
+##4) You may include the -y option to auto-accept updates in some VMs, be careful though.
+##5) Add or remove # in front of the command instructions to disable/enable commands.
+##6) Its essential to keep dom0/templates in sync between repositories, don't mix current and current-testing.
+##7) Only use current-testing if you know what you are getting yourself into (untested updates).
+##8) This script release version is only tested on Qubes 4.0, but presumably may work on Qubes 3.2.
+
+# >>>>To-do-notes<<<<
+##1) Further streamline script, making it easier to customize with symbolic links.
+##2) Reducing the risk that users mistakenly run testing, or out-of-sync dom0/template updates.
+##3) If feasible, presenting the logs for each update, saved in a dated folder for every time script is run.
+##    - If feasible, reporting errors and logs to the user during or after the update has finished.
+##    - If succesful, it removes one of the two major concerns of including the -y attribute, making it easier to use.
+##4) - (Done) Investigate whether --clean can be removed or changed from the dom0 update command.
+##5) Investigate the feasibility of a simple GUI interface to select or de-select script script-options (possibly long-term).
+##6) Fixing the progress bar, and picking the best approach to inform the user.
+##7) A better means to stop the script pre-maturely but safely, because it is a long chain of events to update all VM's.
+
+# >>>>Author<<<<
+## Aekez @ https://github.com/Qubes-Community
+
+# >>>>Feedback & Contributions<<<<
+## Feedback and/or new contributoers are welcome, please use QCC Pull Request, or feel free to contact me.

--- a/code/OS-administration/R4-universal-update-script.sh
+++ b/code/OS-administration/R4-universal-update-script.sh
@@ -18,7 +18,8 @@
 ## within my capability and reach, and reasonable circumstances, such as being aware, and having the time to fix it.
 
 
-
+# /// Special settings \\\
+#toggle-shutdown-sys-whonix='qvm-shutdown sys-whonix --wait' # Enable/Disable this second-last command at bottom of script.
 
 # /// Testing Updates \\\
 ## Removing or inserting the hash-# sign on below lines will disable/enable Qubes testing updates.
@@ -42,16 +43,23 @@ fedora_based_template_1='fedora-28'
 #fedora_based_template_3=''
 #fedora_based_template_4=''
 #fedora_based_template_5=''
+#fedora_based_template_6=''
+#fedora_based_template_7=''
+#fedora_based_template_8=''
+#fedora_based_template_9=''
+#fedora_based_template_10=''
 
 # Debian_based script slots include all Debian / Whonix templates. 
 debian_based_template_1='debian-9'
-#debian_based_template_2=''
-#debian_based_template_3=''
-debian_based_template_4='whonix-ws'
-debian_based_template_5='whonix-gw'
-
-
-
+debian_based_template_2='whonix-ws'
+debian_based_template_3='whonix-gw'
+#debian_based_template_4=''
+#debian_based_template_5=''
+#debian_based_template_6=''
+#debian_based_template_7=''
+#debian_based_template_8=''
+#debian_based_template_9=''
+#debian_based_template_10=''
 
 # /// Inner Script mechanics below \\\
 # You only need to modify the below if you plan to go beyond the normal scope 
@@ -61,128 +69,156 @@ debian_based_template_5='whonix-gw'
 
 # Fedora/Fedora-minimal/CentOS-based update slot #1
 qvm-start "$fedora_based_template_1" #Needed to avoid premature qvm-run shutdown.
-wait
 qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
-wait
 qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf upgrade '$fedora_testing''
-wait
 #qvm-run "$fedora_based_template_1" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown "$fedora_based_template_1" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$fedora_based_template_1" --wait #Needed if qvm-start is used.
 
 # Fedora/Fedora-minimal/CentOS-based update slot #2
 qvm-start "$fedora_based_template_2" #Needed to avoid premature qvm-run shutdown.
-wait
 qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
-wait
 qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf upgrade '$fedora_testing''
-wait
 #qvm-run "$fedora_based_template_2" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown "$fedora_based_template_2" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$fedora_based_template_2" --wait #Needed if qvm-start is used.
 
 # Fedora/Fedora-minimal/CentOS-based update slot #3
 qvm-start "$fedora_based_template_3" #Needed to avoid premature qvm-run shutdown.
-wait
 qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
-wait
 qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf upgrade '$fedora_testing''
-wait
 #qvm-run "$fedora_based_template_3" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown "$fedora_based_template_3" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$fedora_based_template_3" --wait #Needed if qvm-start is used.
 
 # Fedora/Fedora-minimal/CentOS-based update slot #4
 qvm-start "$fedora_based_template_4" #Needed to avoid premature qvm-run shutdown.
-wait
 qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
-wait
 qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf upgrade '$fedora_testing''
-wait
 #qvm-run "$fedora_based_template_4" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown "$fedora_based_template_4" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$fedora_based_template_4" --wait #Needed if qvm-start is used.
 
 # Fedora/Fedora-minimal/CentOS-based update slot #5
 qvm-start "$fedora_based_template_5" #Needed to avoid premature qvm-run shutdown.
-wait
 qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
-wait
 qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf upgrade '$fedora_testing''
-wait
 #qvm-run "$fedora_based_template_5" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-#wait
-qvm-shutdown "$fedora_based_template_5" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$fedora_based_template_5" --wait #Needed if qvm-start is used.
+
+# Fedora/Fedora-minimal/CentOS-based update slot #6
+qvm-start "$fedora_based_template_6" #Needed to avoid premature qvm-run shutdown.
+qvm-run "$fedora_based_template_6" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+qvm-run "$fedora_based_template_6" 'xterm -e sudo dnf upgrade '$fedora_testing''
+#qvm-run "$fedora_based_template_6" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$fedora_based_template_6" --wait #Needed if qvm-start is used.
+
+# Fedora/Fedora-minimal/CentOS-based update slot #7
+qvm-start "$fedora_based_template_7" #Needed to avoid premature qvm-run shutdown.
+qvm-run "$fedora_based_template_7" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+qvm-run "$fedora_based_template_7" 'xterm -e sudo dnf upgrade '$fedora_testing''
+#qvm-run "$fedora_based_template_7" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$fedora_based_template_7" --wait #Needed if qvm-start is used.
+
+# Fedora/Fedora-minimal/CentOS-based update slot #8
+qvm-start "$fedora_based_template_8" #Needed to avoid premature qvm-run shutdown.
+qvm-run "$fedora_based_template_8" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+qvm-run "$fedora_based_template_8" 'xterm -e sudo dnf upgrade '$fedora_testing''
+#qvm-run "$fedora_based_template_8" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$fedora_based_template_8" --wait #Needed if qvm-start is used.
+
+# Fedora/Fedora-minimal/CentOS-based update slot #9
+qvm-start "$fedora_based_template_9" #Needed to avoid premature qvm-run shutdown.
+qvm-run "$fedora_based_template_9" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+qvm-run "$fedora_based_template_9" 'xterm -e sudo dnf upgrade '$fedora_testing''
+#qvm-run "$fedora_based_template_9" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$fedora_based_template_9" --wait #Needed if qvm-start is used.
+
+# Fedora/Fedora-minimal/CentOS-based update slot #10
+qvm-start "$fedora_based_template_10" #Needed to avoid premature qvm-run shutdown.
+qvm-run "$fedora_based_template_10" 'xterm -e sudo dnf update '$fedora_testing' --refresh'
+qvm-run "$fedora_based_template_10" 'xterm -e sudo dnf upgrade '$fedora_testing''
+#qvm-run "$fedora_based_template_10" 'xterm -e sudo dnf autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$fedora_based_template_10" --wait #Needed if qvm-start is used.
 
 
-
+# <<< !!! Switching from Fedora-based to Debian-based updates !!! >>> 
 
 
 # Debian/Whonix-based update slot #1
 qvm-start "$debian_based_template_1" #Needed to avoid premature qvm-run shutdown, important here.
-wait
-qvm-run "$debian_based_template_1" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
-wait
+qvm-run "$debian_based_template_1" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_1" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_1" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-wait
-qvm-shutdown "$debian_based_template_1" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$debian_based_template_1" --wait #Needed if qvm-start is used.
 
 # Debian/Whonix-based update slot #2
 qvm-start "$debian_based_template_2" #Needed to avoid premature qvm-run shutdown, important here.
-wait
-qvm-run "$debian_based_template_2" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
-wait
+qvm-run "$debian_based_template_2" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_2" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_2" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-wait
-qvm-shutdown "$debian_based_template_2" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$debian_based_template_2" --wait #Needed if qvm-start is used.
 
 # Debian/Whonix-based update slot #3
 qvm-start "$debian_based_template_3" #Needed to avoid premature qvm-run shutdown, important here.
-wait
-qvm-run "$debian_based_template_3" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
-wait
+qvm-run "$debian_based_template_3" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_3" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_3" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-wait
-qvm-shutdown "$debian_based_template_3" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$debian_based_template_3" --wait #Needed if qvm-start is used.
 
 # Debian/Whonix-based update slot #4
 qvm-start "$debian_based_template_4" #Needed to avoid premature qvm-run shutdown, important here.
-wait
-qvm-run "$debian_based_template_4" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
-wait
+qvm-run "$debian_based_template_4" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_4" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_4" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-wait
-qvm-shutdown "$debian_based_template_4" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$debian_based_template_4" --wait #Needed if qvm-start is used.
 
 # Debian/Whonix-based update slot #5
 qvm-start "$debian_based_template_5" #Needed to avoid premature qvm-run shutdown, important here.
-wait
-qvm-run "$debian_based_template_5" 'xterm -e sudo apt-get update '$debian_testing'; xterm -e sudo apt-get dist-upgrade '$debian_testing''
-wait
+qvm-run "$debian_based_template_5" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_5" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
 #qvm-run "$debian_based_template_5" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
-wait
-qvm-shutdown "$debian_based_template_5" #Needed if qvm-start is used.
-wait
+qvm-shutdown "$debian_based_template_5" --wait #Needed if qvm-start is used.
+
+# Debian/Whonix-based update slot #6
+qvm-start "$debian_based_template_6" #Needed to avoid premature qvm-run shutdown, important here.
+qvm-run "$debian_based_template_6" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_6" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
+#qvm-run "$debian_based_template_6" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$debian_based_template_6" --wait #Needed if qvm-start is used.
+
+# Debian/Whonix-based update slot #7
+qvm-start "$debian_based_template_7" #Needed to avoid premature qvm-run shutdown, important here.
+qvm-run "$debian_based_template_7" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_7" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
+#qvm-run "$debian_based_template_7" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$debian_based_template_7" --wait #Needed if qvm-start is used.
+
+# Debian/Whonix-based update slot #8
+qvm-start "$debian_based_template_8" #Needed to avoid premature qvm-run shutdown, important here.
+qvm-run "$debian_based_template_8" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_8" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
+#qvm-run "$debian_based_template_8" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$debian_based_template_8" --wait #Needed if qvm-start is used.
+
+# Debian/Whonix-based update slot #9
+qvm-start "$debian_based_template_9" #Needed to avoid premature qvm-run shutdown, important here.
+qvm-run "$debian_based_template_9" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_9" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
+#qvm-run "$debian_based_template_9" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$debian_based_template_9" --wait #Needed if qvm-start is used.
+
+# Debian/Whonix-based update slot #10
+qvm-start "$debian_based_template_10" #Needed to avoid premature qvm-run shutdown, important here.
+qvm-run "$debian_based_template_10" "xterm -e sudo apt-get update '$debian_testing'"
+qvm-run "$debian_based_template_10" "xterm -e sudo apt-get dist-upgrade '$debian_testing'"
+#qvm-run "$debian_based_template_10" 'xterm -e sudo apt autoremove' # Remember you are asked to confirm for a reason, it may not always be a good to autoremove.
+qvm-shutdown "$debian_based_template_10" --wait #Needed if qvm-start is used.
 
 
+$(toggle-shutdown-sys-whonix)
 
 
-
-#qvm-shutdown sys-whonix #Optional.
-#wait
 
 ##Conclusion: Question message, whether to restart or not.
 ##For this part of the Script logic, credit goes to rhss6-2011 @ https://ubuntuforums.org/showthread.php?t=2239195
-ans=$(zenity --width="420" --height="200" --title="uQUS has reached its conclusion." --question --text='The update-script has successfully reached its conflusion.\n\n- Click "Yes" to perform a full system restart.\n\n- Click "No" if no restart is required or you wish to restart manually later.\n\n- It is recommended to minimum restart all AppVMs aftere template updates.\n- If dom0 Qubes OS updates were involved, then it is highly recommended to perform a full system re-start.\n- It may not always clear-cut when a full system restart is needed or not, to be safe just restart the full system.' --ok-label="Yes" --cancel-label="No" 2> /dev/null
+ans=$(zenity --width="520" --height="200" --title="uQUS has reached its conclusion." --question --text='The update-script has successfully reached its conflusion.\n\n- Click "Yes" to perform a full system restart.\n\n- Click "No" if no restart is required or you wish to restart manually later.\n\n- Whenever in doubt, consider a full system reboot.' --ok-label="Yes, shutdown Qubes." --cancel-label="No, keep running." 2> /dev/null
 if [ $? = 0 ] ; then
 command=$(xterm -e shutdown -h now) #use 'reboot -h now' instead of shutdown if you want the 'Yes' button to perform a reboot.
 else


### PR DESCRIPTION
Edit to match to new extra commits.

### Major changes and restructuring ###
- New script feature, script slots for every template.
  - Now much easier to add or change template names in script with a single entry.
  - Normal script user-changes kept at beginning of script.
  - Slots can be expanded or changed if the user needs it.
- Removing the progress status code.
  - Might be re-made later.
- Moving some of the comments and notes to the bottom of the script.

### Minor changes ###
- Including (but default disabled) autoremove command, should the user want to enable it.
- The --clean option is now removed from dom0 update and replaced with --refresh, which seems to work normally in Qubes 4 now.
- Including the fedora upgrade command.
- Removing --refresh from the upgrade command, as refreshing is only needed once from the update command, and makes upgrade act on same info as update, thereby removing the low risk of hitting a repository change between commands, speeding up the time to finish the script updating, and making it overall more reliable.
- ~~Disabling the progress bar, might be re-done later.~~
- Changing default fedora-26 to fedora-28.
- Correcting typo's.