### PR TITLE
WireGuard guide: fix MTU issue

### DIFF
--- a/docs/wireguard/README.md
+++ b/docs/wireguard/README.md
@@ -90,7 +90,7 @@ Create the file `/home/user/wg0.conf` with the following content:
 PrivateKey = <private key of the client>
 Address = 192.168.66.2/32
 DNS = 1.1.1.1
-PostUp = iptables -t nat -I PREROUTING 1 -p udp -m udp --dport 53 -j DNAT --to-destination 1.1.1.1
+PostUp = iptables -t nat -I PREROUTING 1 -p udp -m udp --dport 53 -j DNAT --to-destination 1.1.1.1; iptables -t nat -I POSTROUTING 3 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 [Peer]
 PublicKey = <public key of the client>


### PR DESCRIPTION
Some sites work in sys-wireguard, but did not work in an AppVM
connected to sys-wireguard. Examples:

https://duckduckgo.com
https://atlassian.net

The problem is caused by MTU. The solution was proposed on
https://github.com/QubesOS/qubes-issues/issues/5264#issuecomment-707683771