### PR TITLE
Fix Qubes PulseAudio (Audio and Microphone) in Kali Linux

### DIFF
--- a/docs/os/pentesting/kali.md
+++ b/docs/os/pentesting/kali.md
@@ -50,7 +50,7 @@ access can change this configuration in firewall settings for the TemplateVM.
 
 ```shell_session
 $ gpg --keyserver hkps://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
-$ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 
+$ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
 $ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 ```
 
@@ -128,7 +128,7 @@ the Kali repository, the Qubes testing repository and the Debian testing
 repository.
 So this step [step 8] is currently needed. But it will not always be the case.
 
-9. Update the template 
+9. Update the template
 
 **Note:** During execution of the update, carefully read list of packages to be removed. If it contains `qubes-vm-dependencies` package, terminate operation and try to resolve missing dependencies first. For other `qubes-*` packages, it is up to you to decide if you need them.
 
@@ -144,12 +144,36 @@ At this point you should have a working template and you can install the tools y
 You can find [a list of Kali Linux `Metapackages` here](https://tools.kali.org/kali-metapackages)
 Keep in mind that the tools you will install can easily take more than 10 GB, [so you will need to **grow** the size of the VM system storage.][qubes-resize-disk-image]
 
+Fix Qubes PulseAudio (audio and microphone)
+---------------------------------------------
+Installing the `kali-defaults` package (which is included in many Kali metapackages including `kali-linux-core`) causes Kali PulseAudio configurations files to be installed that interfere with what Qubes provides. This breaks audio and microphone throughput for that qube.
+
+To fix this, simply do one of the following in the Kali Linux TemplateVM:
+
+### Remove just the conflicting PulseAudio configuration files
+
+1.  Remove the configuration files by running the following command:
+
+```shell_session
+# rm /usr/lib/systemd/user/pulseaudio.service.d/kali_pulseaudio.conf /usr/lib/systemd/user/pulseaudio.socket.d/kali_pulseaudio.socket.conf
+```
+
+### Uninstall the entire `kali-defaults` package
+
+1. Assess the function and contents of the package to see if you need it:
+    - See description: `apt show kali-defaults`
+    - See installed files: `dpkg -L kali-defaults`
+2. If you determine that the package is unnecessary, then uninstall it
+    - `sudo apt remove kali-defaults`
+
+Finally, for both of these options, the Kali Linux qube will have to be restarted for these changes to take effect.
+
 Alternative Options to Kali Linux
 ===================================
 * [PenTester Framework][PTF], with [PTF Qubes OS guide][qubes-ptf]
 * BlackArch Linux, with [BA Qubes OS guide][qubes-blackarch]
 * more on the [Penetration Testing page][qubes-pentesting]
- 
+
 
 Notes
 =============


### PR DESCRIPTION
This pull request adds documentation for fixing the Qubes PulseAudio configuration (audio and microphone) after being broken as a result of installing the `kali-defaults` package in Kali Linux.

The `kali-defaults` package is a very common package installed by many [Kali Linux metapackages](https://tools.kali.org/kali-metapackages) (including `kali-linux-core`). Here is the description provided by the package:
```
 This package implements various default settings within Kali.
 
 The size of this package (including its dependencies) should be rather limited
 because it is included in all Kali images, even minimalistic ones such as
 docker images.
```