### PR TITLE
Fix multiple issues in qvm-copy-to-vm2.sh

### DIFF
--- a/code/productivity/qvm-copy-to-vm2.sh
+++ b/code/productivity/qvm-copy-to-vm2.sh
@@ -4,12 +4,12 @@
 # qvm-copy-to-dom0 <Source in dom0> <AppVM> <Destination in dom0>
 
 # command line parameters
-Source=$1      # must be present
-AppVM=$2       # must be present
-Destination=$3 # must be present
+Source="$1"      # must be present
+AppVM="$2"       # must be present
+Destination="$3" # must be present
 
 # if no Destination given on commandline use /home/user/QubesIncoming
-if [ -z "$3" ];then Destination=/home/user/QubesIncoming; fi
+if [ -z "$Destination" ];then Destination="/home/user/QubesIncoming"; fi
 
 # copy file from dom0 to AppVM
-qvm-run --pass-io $AppVM "cat $Source" > $Destination
+qvm-run --pass-io $AppVM "cat -- \"$Source\"" > "$Destination"


### PR DESCRIPTION
Fix multiple issues with filenames containing spaces and starting dashes.
The result is not tested by me at all, please check the changes before use.