### PR TITLE
Update instructions for Kali install

### DIFF
--- a/docs/os/pentesting/kali.md
+++ b/docs/os/pentesting/kali.md
@@ -49,7 +49,7 @@ access can change this configuration in firewall settings for the TemplateVM.
 1. Retrieve the Kali Linux PGP key using a DisposableVM.
 
 ```shell_session
-$ gpg --keyserver hkps://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
+$ gpg --keyserver hkps://keys.openpgp.org --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
 $ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
 $ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 ```


### PR DESCRIPTION
hkps://keys.gnupg.net does not resolve any longer. Kali official docs recommend hkps://keys.openpgp.org

source: https://www.kali.org/docs/introduction/download-official-kali-linux-images/