### PR TITLE
Update Wikipedia info & polish style in signal.md

### DIFF
--- a/docs/privacy/signal.md
+++ b/docs/privacy/signal.md
@@ -11,48 +11,50 @@ What is [Signal]?
 > communications to other Signal users. Signal can be used to send and receive
 > encrypted instant messages, group messages, attachments and media messages.
 > Users can independently verify the identity of their messaging correspondents
-> by comparing key fingerprints out-of-band. During calls, users can check the
-> integrity of the data channel by checking if two words match on both ends of
-> the call.
+> by comparing key fingerprints out-of-band.
 > 
-> Signal is developed by Open Whisper Systems. The clients are published as free
-> and open-source software under the GPLv3 license.
+> Signal is developed by Signal Technology Foundation and Signal Messenger LLC.
+> The mobile clients for  are published as free and open-source software under
+> the GPLv3 license, while the desktop client and server are published under the
+> AGPL-3.0-only license.
 
-How to install Signal in Qubes
-------------------------------
+How to install Signal Desktop in Qubes
+--------------------------------------
 
 **CAUTION:** Before proceeding, please carefully read [On Digital Signatures and Key Verification][qubes-verifying-signatures].
 This website cannot guarantee that any PGP key you download from the Internet is authentic.
 Always obtain a trusted key fingerprint via other channels, and always check any key you download against your trusted copy of the fingerprint.
 
-1. (Optional)Create a TemplateVM (Debian, 11 is used as an example)
+The following adapts the official [Linux (Debian-based) Install Instructions][signal-debian-instructions] from Signal's website for Qubes.
+
+1. (Optional) Create a TemplateVM (Debian 11 is used as an example):
 
        [user@dom0 ~]$ sudo qubesctl --skip-dom0 --targets=debian-11 --show-output state.sls update.qubes-vm
 
-2. Open a terminal in Debian 11 (Or your previously chosen template)
+2. Open a terminal in Debian 11 (or your previously chosen template):
 
        [user@dom0 ~]$ qvm-run -a debian-11 gnome-terminal
        
-3. Use these commands in your terminal (If you chose a different distribution, such as buster, substitute that for xenial in the 4th command)
+3. Use these commands in your terminal (if you chose a different distribution, such as `buster`, substitute that for `xenial` in the fourth command):
 
-       (Optional)[user@debian-11 ~]$ sudo apt-get install curl
-       (for better signal notifications)[user@debian-11 ~]$ sudo apt-get install dunst
+       [user@debian-11 ~]$ sudo apt-get install curl  # (Optional)
+       [user@debian-11 ~]$ sudo apt-get install dunst  # (for better Signal notifications)
        [user@debian-11 ~]$ curl --proxy 127.0.0.1:8082 -s https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor | sudo tee -a /usr/share/keyrings/signal-desktop-keyring.gpg > /dev/null
        [user@debian-11 ~]$ echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt xenial main' | sudo tee -a /etc/apt/sources.list.d/signal-xenial.list
        [user@debian-11 ~]$ sudo apt update && sudo apt full-upgrade && sudo apt install --no-install-recommends signal-desktop
 
-5. Shutdown the TemplateVM (substitute your template name if needed) :
+5. Shutdown the TemplateVM (substitute your template name if needed):
 
         [user@dom0 ~]$ qvm-shutdown debian-11
         
-6. Create an AppVM based on this TemplateVM
-7. With your mouse select the `Q` menu -> `Domain: "AppVM Name"` -> `"AppVM Name": Qube Settings` -> `Applications`
-(or in Qubes Manager`"AppVM Name"` -> `Settings` -> `Applications`). Select `Signal` from the left `Available` column, move it to the right `Selected` column by clicking the `>` button and then `OK` to apply the changes and close the window.
+6. Create an AppVM based on this TemplateVM.
+7. With your mouse, select the `Q` menu -> `Domain: "AppVM Name"` -> `"AppVM Name": Qube Settings` -> `Applications` (or in Qubes Manager `"AppVM Name"` -> `Settings` -> `Applications`). Select `Signal` from the left `Available` column, move it to the right `Selected` column by clicking the `>` button and then `OK` to apply the changes and close the window.
 
 -----
 
 [qubes-verifying-signatures]: https://www.qubes-os.org/security/verifying-signatures/
-[Signal]: https://whispersystems.org/
+[Signal]: https://signal.org/
+[signal-debian-instructions]: https://www.signal.org/download/linux/
 [signal-wikipedia]: https://en.wikipedia.org/wiki/Signal_(software)
 [shortcut]: https://support.whispersystems.org/hc/en-us/articles/216839277-Where-is-Signal-Desktop-on-my-computer-
 [shortcut-desktop]: https://www.qubes-os.org/doc/managing-appvm-shortcuts/#tocAnchor-1-1-1


### PR DESCRIPTION
* Change URL from Open Whisper Systems site to Signal's site (the former always redirects to the latter anyways)
* Delete mention of checking if two words match during 1-on-1 Signal calls in block quote (I haven't seen this on Signal mobile since at least October 2020, when group calls came to desktop & iPad)
* Update info on Signal being developed/supported by Signal Foundation and Signal Messenger LLC, which have superseded Open Whisper Systems after 2018
* Add distinction of FOSS license between mobile clients and desktop client+server
* State clearly that Signal Desktop will be installed on Qubes OS
* Add reference to official Linux instructions from Signal
* Move clarifying notes in Step 3 commands to Bash comments at end of file, to better simulate terminal emulator standard output
* Make typographical style more consistent throughout the list