### PR TITLE
add link to forum wiki / crowdsourcing user experience

### DIFF
--- a/docs/os/windows/windows-tools.md
+++ b/docs/os/windows/windows-tools.md
@@ -1,3 +1,5 @@
+:warning: *Some of the information below is outdated ; please read [this forum wiki post](https://forum.qubes-os.org/t/wip-windows-qwt-user-reports/9687) for up to date instructions and users feedback.
+The content below will eventually be updated to reflect the newer 4.1 release and QWT recent development (contributors welcome!)*
 
 Qubes Windows Tools
 ===================

--- a/docs/os/windows/windows-vm.md
+++ b/docs/os/windows/windows-vm.md
@@ -1,4 +1,5 @@
-
+:warning: *Some of the information below is outdated ; please read [this forum wiki post](https://forum.qubes-os.org/t/wip-windows-qwt-user-reports/9687) for current instructions and users feedback.
+The content below will eventually be updated to reflect the newer 4.1 release and QWT recent development (contributors welcome!)*
 
 Installing a Windows VM
 =======================

--- a/docs/os/windows/windows-vm.md
+++ b/docs/os/windows/windows-vm.md
@@ -1,4 +1,4 @@
-:warning: *Some of the information below is outdated ; please read [this forum wiki post](https://forum.qubes-os.org/t/wip-windows-qwt-user-reports/9687) for current instructions and users feedback.
+:warning: *Some of the information below is outdated ; please read [this forum wiki post](https://forum.qubes-os.org/t/wip-windows-qwt-user-reports/9687) for up to date instructions and users feedback.
 The content below will eventually be updated to reflect the newer 4.1 release and QWT recent development (contributors welcome!)*
 
 Installing a Windows VM


### PR DESCRIPTION
Some of the information in the windows docs is outdated given the recent work on QWT and the recent 4.1 release. Following a [discussion in this post](https://forum.qubes-os.org/t/wip-windows-qwt-user-reports/9687) and a few forum posts showing that people were confused with the current instructions, it seems helpful to direct users to more up-to-date documentation (albeit "telegraphic") until somebody updates the current docs - which might take a bit of time.

Note: an alternative is to dismiss this PR and add a link to the forum wiki post in the [official doc](https://www.qubes-os.org/doc/windows/)