### PR TITLE
vpn.md: Fix hang on proxyVM shutdown

### DIFF
--- a/docs/configuration/vpn.md
+++ b/docs/configuration/vpn.md
@@ -210,8 +210,12 @@ Before proceeding, you will need to download a copy of your VPN provider's confi
    su - -c 'notify-send "$(hostname): LINK IS DOWN !" --icon=dialog-error' user
    
    # Restart the VPN automatically
-   sleep 5s
-   sudo /rw/config/rc.local
+   if [[! -e /run/systemd/shutdown/scheduled ]] ; then
+	    sleep 5s
+	    sudo /rw/config/rc.local
+   else
+	    exit 0
+   fi
    ;;
    esac
    ~~~

--- a/docs/configuration/vpn.md
+++ b/docs/configuration/vpn.md
@@ -210,7 +210,7 @@ Before proceeding, you will need to download a copy of your VPN provider's confi
    su - -c 'notify-send "$(hostname): LINK IS DOWN !" --icon=dialog-error' user
    
    # Restart the VPN automatically
-   if [[! -e /run/systemd/shutdown/scheduled ]] ; then
+   if [[ ! -e /run/systemd/shutdown/scheduled ]] ; then
 	    sleep 5s
 	    sudo /rw/config/rc.local
    else


### PR DESCRIPTION
I changed qubes-vpn-handler.sh to check for a scheduled shutdown.
This will cause a clean exit of the openvpn down option in case the VM is requested to shut down.
I use a debian-11-minimal-template on Qubes 4.1 for the openvpn-vm.
Without my workaround the shutdown (e.g. via qvm-shutdown) hangs for the default 90 seconds with "A stop job is running for Qubes mis...post-boot actions".