### PR TITLE
Qube firewall rules for VPN Qube

### DIFF
--- a/docs/configuration/vpn.md
+++ b/docs/configuration/vpn.md
@@ -80,11 +80,13 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
    ip6tables -I FORWARD -i eth0 -j DROP
    ```
 
-6. Configure your AppVMs to use the new VM as a NetVM.
+6. (Optional) Configure the VPN Qube firewall rules so it **only** allows the VPN endpoint address. This is much quicker and can be done graphically, unlike the optional points mentioned above.
+
+7. Configure your AppVMs to use the new VM as a NetVM.
 
    ![Settings-NetVM.png](/attachment/wiki/VPN/Settings-NetVM.png)
 
-7. Optionally, you can install some [custom icons](https://github.com/Zrubi/qubes-artwork-proxy-vpn) for your VPN
+8. Optionally, you can install some [custom icons](https://github.com/Zrubi/qubes-artwork-proxy-vpn) for your VPN
 
 
 Set up a ProxyVM as a VPN gateway using iptables and CLI scripts

--- a/docs/configuration/vpn.md
+++ b/docs/configuration/vpn.md
@@ -80,7 +80,7 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
    ip6tables -I FORWARD -i eth0 -j DROP
    ```
 
-6. (Optional) Configure the VPN Qube firewall rules so it **only** allows the VPN endpoint address. This is much quicker and can be done graphically, unlike the optional points mentioned above.
+6. (Optional) Configure the VPN Qube firewall rules so it **only** allows the VPN endpoint address. This is much quicker and can be done graphically, unlike the optional points mentioned above. However, while quicker, it is not as "strict" as the one above. See [PR#220](https://github.com/Qubes-Community/Contents/pull/220#discussion_r1001357914) for more information.
 
 7. Configure your AppVMs to use the new VM as a NetVM.
 


### PR DESCRIPTION
Configure the VPN Qube firewall rules so it **only** allows the VPN endpoint address.
Much easier, quicker than some other methods and can be done graphically rather than with a command line.