### PR TITLE
Where they exist, point to where these articles now are.

### DIFF
--- a/docs/building/building-archlinux-template.md
+++ b/docs/building/building-archlinux-template.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/archlinux-minimal-template/19052). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/building/building-non-fedora-template.md
+++ b/docs/building/building-non-fedora-template.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/building-a-templatevm-for-a-new-os/18972). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/building/building-whonix-template.md
+++ b/docs/building/building-whonix-template.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/building-whonix-templates/18981). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/common-tasks/copying-files-to-dom0.md
+++ b/docs/common-tasks/copying-files-to-dom0.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/copying-files-to-dom0/19025). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/common-tasks/opening-urls-in-vms.md
+++ b/docs/common-tasks/opening-urls-in-vms.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/opening-urls-files-in-other-qubes/19026). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/common-tasks/setup-trezor-cryptocurrency-hardware-wallet.md
+++ b/docs/common-tasks/setup-trezor-cryptocurrency-hardware-wallet.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/setting-up-a-trezor-cryptocurrency-hardware-wallet/19053). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/common-tasks/uqus-doc.md
+++ b/docs/common-tasks/uqus-doc.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/bluetooth.md
+++ b/docs/configuration/bluetooth.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/graphical-bluetooth-configuration/18982). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/change-time-zone.md
+++ b/docs/configuration/change-time-zone.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/changing-your-time-zone/18983). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/disk-trim.md
+++ b/docs/configuration/disk-trim.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/disk-trimming/19054). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/external-audio.md
+++ b/docs/configuration/external-audio.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/using-external-audio-devices/18984). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/fetchmail.md
+++ b/docs/configuration/fetchmail.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/fetchmail/18985). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/http-proxy.md
+++ b/docs/configuration/http-proxy.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/how-to-run-an-http-filtering-proxy/18986). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/install-nvidia-driver.md
+++ b/docs/configuration/install-nvidia-driver.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/nvidia-proprietary-driver-installation/18987). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/multiboot.md
+++ b/docs/configuration/multiboot.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/multibooting-qubes/18988). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/multimedia.md
+++ b/docs/configuration/multimedia.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/configuring-a-multimedia-templatevm/19055). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/mutt.md
+++ b/docs/configuration/mutt.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/mutt-mail-user-agent/18989). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/network-bridge-support.md
+++ b/docs/configuration/network-bridge-support.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/network-bridge-support-experimental-and-unsupported/18990). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/network-printer.md
+++ b/docs/configuration/network-printer.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/configuring-a-network-printer/19056). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/postfix.md
+++ b/docs/configuration/postfix.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/postfix-mta/18991). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/qmenu.md
+++ b/docs/configuration/qmenu.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/manage-qubes-via-dmenu-qmenu/19058). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/rxvt.md
+++ b/docs/configuration/rxvt.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/rxvt-terminal/18992). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/screen-share.md
+++ b/docs/configuration/screen-share.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/sharing-a-screen-across-qubes/19059). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/shrink-volumes.md
+++ b/docs/configuration/shrink-volumes.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/shrinking-volumes/19027). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/split-ssh.md
+++ b/docs/configuration/split-ssh.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/split-ssh/19060). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/tips-and-tricks.md
+++ b/docs/configuration/tips-and-tricks.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/vpn.md
+++ b/docs/configuration/vpn.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/configuring-a-proxyvm-vpn-gateway/19061). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/w3m.md
+++ b/docs/configuration/w3m.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/reducing-the-fingerprint-of-the-text-based-web-browser-w3m/18993). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/zfs.md
+++ b/docs/configuration/zfs.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/zfs-in-qubes-os/18994). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/configuration/zoom_dispvm.md
+++ b/docs/configuration/zoom_dispvm.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/running-zoom-in-a-dispvm/19062). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/coreboot/x230.md
+++ b/docs/coreboot/x230.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/coreboot-on-lenovo-x230/19063). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/awesomewm.md
+++ b/docs/customization/awesomewm.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/awesomewm-customizations/18995). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/dark-theme.md
+++ b/docs/customization/dark-theme.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/dark-theme-in-dom0/18997). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/dpi-scaling.md
+++ b/docs/customization/dpi-scaling.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/dpi-scaling/19064). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/fedora-minimal-template-customization.md
+++ b/docs/customization/fedora-minimal-template-customization.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/fedora-packages-recommendations/18999). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/gaming-hvm.md
+++ b/docs/customization/gaming-hvm.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/create-a-gaming-hvm/19000). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/language-localization.md
+++ b/docs/customization/language-localization.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/language-localization/19001). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/mirage-firewall.md
+++ b/docs/customization/mirage-firewall.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/mirage-firewall/19065). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/removing-templatevm-packages.md
+++ b/docs/customization/removing-templatevm-packages.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/safely-uninstalling-packages-in-templatevms/19002). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/screenlockers.md
+++ b/docs/customization/screenlockers.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/custom-screenlockers/19003). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/secbrowser.md
+++ b/docs/customization/secbrowser.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/secbrowser-deprecated/19066). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/tailscale.md
+++ b/docs/customization/tailscale.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/tailscale/19004). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/terminal-defaults.md
+++ b/docs/customization/terminal-defaults.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/setting-default-terminal-settings-for-a-templatevm/19067). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/customization/windows-template-customization.md
+++ b/docs/customization/windows-template-customization.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/disable-uninstall-unnecessary-features-in-windows-qubes/19005). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/hardware/Autonomous Qubes-install (kickstart).md
+++ b/docs/hardware/Autonomous Qubes-install (kickstart).md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/hardware/fixing-booting-issues-compendium.md
+++ b/docs/hardware/fixing-booting-issues-compendium.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/hardware/hardware-selection.md
+++ b/docs/hardware/hardware-selection.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/localization/keyboard-multiple-layouts.md
+++ b/docs/localization/keyboard-multiple-layouts.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/using-multiple-keyboard-layouts/19029). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/localization/multi-language-support-dom0.md
+++ b/docs/localization/multi-language-support-dom0.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/using-multiple-languages-in-dom0/19068). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/misc/qubes-evaluation-walkthrough.md
+++ b/docs/misc/qubes-evaluation-walkthrough.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/evaluating-qubes-os-walkthrough/19069). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/mumble/README.md
+++ b/docs/mumble/README.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/exposing-mumble-server-running-in-qubes-using-wireguard/19070). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/centos.md
+++ b/docs/os/centos.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/centos-rhel-clone-8-templatevm/19006). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/gentoo.md
+++ b/docs/os/gentoo.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/gentoo-templatevm/19007). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/linux-hvm-tips.md
+++ b/docs/os/linux-hvm-tips.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/tips-for-linux-hvms/19008). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/netbsd.md
+++ b/docs/os/netbsd.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/netbsd-qube/19009). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/pentesting.md
+++ b/docs/os/pentesting.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/pentesting/blackarch.md
+++ b/docs/os/pentesting/blackarch.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/blackarch-templatevm/19010). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/pentesting/kali.md
+++ b/docs/os/pentesting/kali.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/creating-a-kali-linux-templatevm/19071). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/pentesting/ptf.md
+++ b/docs/os/pentesting/ptf.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/penetration-testers-framework-ptf-templatevm/19011). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/ubuntu.md
+++ b/docs/os/ubuntu.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/windows/windows-migrate41.md
+++ b/docs/os/windows/windows-migrate41.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/windows/windows-tools.md
+++ b/docs/os/windows/windows-tools.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/windows/windows-tools41.md
+++ b/docs/os/windows/windows-tools41.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/windows/windows-vm.md
+++ b/docs/os/windows/windows-vm.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/windows/windows-vm41.md
+++ b/docs/os/windows/windows-vm41.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/os/windows/windows.md
+++ b/docs/os/windows/windows.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/privacy/anonymizing-your-mac-address.md
+++ b/docs/privacy/anonymizing-your-mac-address.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/anonymizing-your-mac-address/19072). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/privacy/signal.md
+++ b/docs/privacy/signal.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/signal-messenger/19073). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/privacy/tails.md
+++ b/docs/privacy/tails.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/tails-hvm/19012). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/privacy/torvm.md
+++ b/docs/privacy/torvm.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/torvm-qubes-tor-deprecated/19013). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/privacy/whonix.md
+++ b/docs/privacy/whonix.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/whonix-for-privacy-anonymity/19014). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/security/forensics.md
+++ b/docs/security/forensics.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/forensics-in-qubes-os/19015). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/security/multifactor-authentication.md
+++ b/docs/security/multifactor-authentication.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/using-multi-factor-authentication/19016). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/security/replacing-passwordless-root-with-dom0-prompt.md
+++ b/docs/security/replacing-passwordless-root-with-dom0-prompt.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/replacing-passwordless-root-with-a-dom0-prompt/19074). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/security/security-guidelines.md
+++ b/docs/security/security-guidelines.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/general-security-guidelines/19075). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/security/split-bitcoin.md
+++ b/docs/security/split-bitcoin.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/how-to-set-up-a-split-bitcoin-wallet/19017). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/security/split-gpg.md
+++ b/docs/security/split-gpg.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/using-split-gpg-with-subkeys/19076). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/system/backup-reminders.md
+++ b/docs/system/backup-reminders.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/backup-reminder/19078). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/system/clock-time.md
+++ b/docs/system/clock-time.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/understanding-and-fixing-issues-with-time-clock/19030). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/system/restore-3.2.md
+++ b/docs/system/restore-3.2.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/restoring-r3-2-templates-standalones-to-r4-0/19018). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/system/vm-console.md
+++ b/docs/system/vm-console.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/connect-to-a-qubes-console/19079). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/system/vm-image.md
+++ b/docs/system/vm-image.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/mounting-a-qubes-private-storage-in-another-qube/19080). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/troubleshooting/application-troubleshooting.md
+++ b/docs/troubleshooting/application-troubleshooting.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/troubleshooting-default-applications/19019). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/troubleshooting/intel-igfx-troubleshooting.md
+++ b/docs/troubleshooting/intel-igfx-troubleshooting.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/intel-integrated-graphics-troubleshooting/19081). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/troubleshooting/macbook-troubleshooting.md
+++ b/docs/troubleshooting/macbook-troubleshooting.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/apple-macbook-troubleshooting/19020). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/troubleshooting/nvidia-troubleshooting.md
+++ b/docs/troubleshooting/nvidia-troubleshooting.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/nvidia-troubleshooting-guide/19021). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/troubleshooting/sony-vaio-tinkering.md
+++ b/docs/troubleshooting/sony-vaio-tinkering.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/sony-vaio-z-laptop-troubleshooting/19022). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/troubleshooting/tails-troubleshooting.md
+++ b/docs/troubleshooting/tails-troubleshooting.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/tails-troubleshooting-guide/19023). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/troubleshooting/thinkpad-troubleshooting.md
+++ b/docs/troubleshooting/thinkpad-troubleshooting.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/lenovo-thinkpad-troubleshooting/19024). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/user-setups/README.md
+++ b/docs/user-setups/README.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/user-setups/one7two99/README.md
+++ b/docs/user-setups/one7two99/README.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/user-setups/raffaeleflorio/README.md
+++ b/docs/user-setups/raffaeleflorio/README.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/user-setups/taradiddles/README.md
+++ b/docs/user-setups/taradiddles/README.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content was removed as part of the migration to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)

--- a/docs/wireguard/README.md
+++ b/docs/wireguard/README.md
@@ -1,1 +1,1 @@
-This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/c/guides/14). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)
+This content has moved to [Qubes Forum: Community Guides](https://forum.qubes-os.org/t/wireguard/19082). [Learn more.](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367/)


### PR DESCRIPTION
Where they don't, mention that.

Finding matches for these required access to the text of the old versions. Without javascript, there's no search at all, and the text as it is has the potential to waste a lot of time for people looking for articles that did not survive the migration.

One thing that's definitely missing here is an explanation for *why* stuff is missing where that's the case. If there's a better source for the information that used to be represented (or if it is believed to no longer be useful), it's probably worth pointing to that instead.